### PR TITLE
use main branch instead of master

### DIFF
--- a/micropython_typesheds.py
+++ b/micropython_typesheds.py
@@ -43,7 +43,7 @@ def main():
         )
 
     with urlopen(
-        "https://github.com/hlovatt/PyBoardTypeshed/archive/master.zip"
+        "https://github.com/hlovatt/PyBoardTypeshed/archive/main.zip"
     ) as http_response:
         with ZipFile(BytesIO(http_response.read())) as zipfile:
             typesheds: Final = [f for f in zipfile.namelist() if f.endswith(".pyi")]
@@ -51,7 +51,7 @@ def main():
                 zipfile.extractall(path=temp_top_level, members=typesheds)
                 temp_typeshed_level = (
                     Path(temp_top_level)
-                    / "PyBoardTypeshed-master"
+                    / "PyBoardTypeshed-main"
                     / "micropython_typesheds"
                 )
                 for file in scandir(temp_typeshed_level):


### PR DESCRIPTION
Fix:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/vincent/Documents/cours/documentation/python/micropython/venv/lib/python3.8/site-packages/micropython_typesheds.py", line 64, in <module>
    main()
  File "/home/vincent/Documents/cours/documentation/python/micropython/venv/lib/python3.8/site-packages/micropython_typesheds.py", line 59, in main
    for file in scandir(temp_typeshed_level):
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp65xb808_/PyBoardTypeshed-master/micropython_typesheds'
```